### PR TITLE
handling possible missing mp4: prefix from JW Player

### DIFF
--- a/src/bookmarklets/sherd.js
+++ b/src/bookmarklets/sherd.js
@@ -814,6 +814,20 @@ SherdBookmarklet = {
                           c = obj.getConfig(), 
                           pcfg = obj.getPluginConfig('http');
                       if (item.type == 'rtmp') {
+                      	 // ensure that mp4 rtmp files contain the
+                         // needed mp4: prefix so that they will play
+                         // properly in flowplayer;
+                         // JW Player allows you to omit this prefix,
+                         // but Flowplayer does not
+                         //
+                         // if item.file ends with mp4,
+                         // and item.file does not already begin with mp4:,
+                         // then append mp4: to item.file
+                         if ( (/mp4$/.test(item.file)) &&
+                              !(/^mp4:/.test(item.file)) ) {
+                            item.file = 'mp4:' + item.file;
+                         }
+
                           rv.sources["video_rtmp"] = item.streamer+'//'+item.file;
                           rv.primary_type = "video_rtmp";
                       } else {


### PR DESCRIPTION
(apologies if I'm not using github correctly -- I'm new to it)

So, after looking at this a bit more, I see that the "missing mp4:" is something that JW Player in particular allows:

---

From [ http://www.longtailvideo.com/support/jw-player/jw-player-for-flash-v5/12535/video-delivery-rtmp-streaming ]:

Note that the documentation of RTMP servers tell you to set the file option in players like this:

For FLV video: file=clip (without the .flv extension).
For MP4 video: file=mp4:clip.mp4 (with mp4: prefix).
For MP3 audio: file=mp3:song.mp3 (with mp3: prefix).
For AAC audio: file=mp4:song.aac (with mp4: prefix).

You do not have to do this with the JW Player, since the player takes care of stripping the extension and/or adding the prefix. If you do add the prefix yourself, the player will recognize it and not modify the URL.

---

So, I assume the missing mp4: is something that we could expect to see with other instances of JW Player -- so perhaps it makes sense to deal with it in the generic jwplayer assethandler rather than in a specialized hosthandler section?
