### PR TITLE
Flickr 'archive' metadata conflicts with asset display

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.4.7.tar.gz
+tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.4.8.tar.gz

--- a/sherdjs/src/bookmarklets/sherd.js
+++ b/sherdjs/src/bookmarklets/sherd.js
@@ -502,7 +502,7 @@ SherdBookmarklet = {
                                         "title": getInfoData.photo.title._content,
                                         "thumb": thumb_url,
                                         "image": img_url,
-                                        "archive": "http://www.flickr.com/photos/" + getInfoData.photo.owner.nsid, /* owner's photostream */
+                                        "metadata-photostream": "http://www.flickr.com/photos/" + getInfoData.photo.owner.nsid, /* owner's photostream */
                                         "image-metadata":"w"+w+"h"+h,
                                         "metadata-owner":getInfoData.photo.owner.realname ||undefined
                                     };


### PR DESCRIPTION
swap out archive display for 'metadata-photostream'