### PR TITLE
Support YouTube v3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.4.9.tar.gz
+tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.0.tar.gz

--- a/sherdjs/src/bookmarklets/sherd.js
+++ b/sherdjs/src/bookmarklets/sherd.js
@@ -199,6 +199,10 @@ SherdBookmarklet = {
           window.SherdBookmarklet.options.youtube_apikey = user_status.youtube_apikey;
       }
 
+      if ('flickr_apikey' in user_status) {
+          window.SherdBookmarklet.options.flickr_apikey = user_status.flickr_apikey;
+      }
+
       //Safari sometimes loads logged_in.js last, even when added first
       if (uninit && user_status.ready && SherdBookmarklet.g) {
           //find assets again


### PR DESCRIPTION
* v2 is fully deprecated
* remove Mondrian references.
* pickup youtube api key from the 'user_status' server interaction. this seems to be the most flexible approach. 