### PR TITLE
Remove create selection hack

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.5.2 (2015-07-24)
+==================
+* Remove create selection hack.
+
 0.5.1 (2015-07-22)
 ==================
 * Handle some null cases in clipform.js

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.1.tar.gz
+tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.2.tar.gz

--- a/sherdjs/src/configs/djangosherd.js
+++ b/sherdjs/src/configs/djangosherd.js
@@ -420,8 +420,7 @@ CitationView.prototype.displayCitation = function (anchor, ann_obj, id) {
         "clipstrip": jQuery(asset_target).find('div.clipstrip-display').get(0),
         "asset": jQuery(asset_target).find('div.asset-display').get(0),
         "asset_title": jQuery(asset_target).find('div.asset-title').get(0),
-        "annotation_title": jQuery(asset_target).find('div.annotation-title').get(0),
-        "create_selection": jQuery(asset_target).find('div.create-selection', asset_target).get(0)
+        "annotation_title": jQuery(asset_target).find('div.annotation-title').get(0)
     };
     
     if (targets.annotation_title) {
@@ -441,11 +440,7 @@ CitationView.prototype.displayCitation = function (anchor, ann_obj, id) {
         asset_obj.autoplay = (self.options.autoplay) ? self.options.autoplay : false;
         asset_obj.presentation = self.options.presentation || 'small';
 
-        if (targets.asset_title) {
-            if (targets.create_selection) {
-                targets.create_selection.innerHTML = '<a href="' + asset_obj.local_url + '#edit_state=new">Create Selection</a>';
-            }
-            
+        if (targets.asset_title) {            
             if (targets.annotation_title.innerHTML === "") {
                 targets.annotation_title.innerHTML = '<a href="' + asset_obj.local_url + '">' + asset_obj.title + '</a>';
                 targets.asset_title.innerHTML = '&nbsp;';


### PR DESCRIPTION
A create selection link was hacked into the project item view space to ease the user experience. The selection assignment will remove the need for this.