### PR TITLE
switch travis environment to nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: javascript
+language: node_js
 # before_script:
 #   - npm install jshint --prefix .
 #   - npm install jscs --prefix .


### PR DESCRIPTION
`javascript` is getting interpreted as 'java'. see: https://travis-ci.org/ccnmtl/SherdJS/builds/73613748