### PR TITLE
Fix clipform bugs with youtube player

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.5.7 (2015-09-16)
+==================
+* Fix clipform bug in YouTube viewer
+
 0.5.6 (2015-09-16)
 ==================
 * Use YouTube iframe API for displaying youtube videos

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.6.tar.gz
+tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.7.tar.gz

--- a/sherdjs/src/assets.js
+++ b/sherdjs/src/assets.js
@@ -41,7 +41,9 @@ if (!Sherd.GenericAssetView) {
                 decorateVideo(options, quicktime);
             }
             if (Sherd.Video.YouTube) {
-                var youtube = this.settings.youtube = {'view': new Sherd.Video.YouTube() };
+                var youtube = this.settings.youtube = {
+                    'view': new Sherd.Video.YouTube()
+                };
                 decorateVideo(options, youtube);
             }
             if (Sherd.Video.Flowplayer) {

--- a/sherdjs/src/base.js
+++ b/sherdjs/src/base.js
@@ -123,7 +123,19 @@ Sherd.Base = {
                 // /but we should have it clobber
                 // /until we need it
                 if (self.microformat && self.microformat.components) {
-                    self.components = self.microformat.components(dom, create_obj);
+                    var possiblePromise = self.microformat.components(dom, create_obj);
+
+                    if (possiblePromise &&
+                        typeof possiblePromise.done === 'function'
+                       ) {
+                        possiblePromise.done(function(components) {
+                            self.components = components;
+                        });
+                    } else if (typeof possiblePromise === 'object') {
+                        self.components = possiblePromise;
+                    } else {
+                        console.error('components error:', possiblePromise);
+                    }
                 } else {
                     self.components = {
                         'top' : dom


### PR DESCRIPTION
This took me forever to fix, including some wrong turns. The problem
was that, when navigating to new youtube videos, the clipform controls
weren't connected to the new video, because the old Sherd.Video.YouTube
instance is still present -- a new one isn't created.

Creating a new Sherd.Video.YouTube instance for each video (which is
what seems like should happen) is not worth the large effort that would
take -- it goes against SherdJS's current architecture. Instead, I've
found a way to make sure the state stays correct with promises, and lots
of sanity checks/debugging.