### PR TITLE
Release SherdJS 0.5.8

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.5.8 (2015-10-07)
+==================
+* Fix bug where <video> metadata wasn't getting collected.
+* Use poster attribute as <video> thumbnail.
+
 0.5.7 (2015-09-16)
 ==================
 * Fix clipform bug in YouTube viewer

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.7.tar.gz
+tar -c --exclude='.*' --exclude='build.sh' --exclude='package.json' -f - * | gzip > sherdjs-0.5.8.tar.gz

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "SherdJS",
-  "version": "0.5.6",
+  "version": "0.5.8",
   "author": "Schuyler Duveen <sky@skyb.us>",
   "description": "A Javascript library that 'knows' how to display and annotate (and maybe embed) objects into certain contexts.",
   "contributors": [ 
     {
       "name": "Susan Dreher",
       "email": "sdreher@columbia.edu"
+    },
+    {
+      "name": "Nik Nyby",
+      "email": "nnyby@columbia.edu"
     } 
   ],
   "repository": {


### PR DESCRIPTION
With fixes for the video tag.